### PR TITLE
WIP: bugfix for rotateBarrelTo

### DIFF
--- a/src/bot/functions/function-utils.js
+++ b/src/bot/functions/function-utils.js
@@ -1,5 +1,5 @@
+// Standardize angle to between 0 and Math.PI*2
 const standardizeAngle = function(radianAngle) {
-    // standardize angle to between 0 and Math.PI*2
     while (radianAngle > Math.PI*2) {
       radianAngle -= Math.PI*2;
     }
@@ -10,6 +10,12 @@ const standardizeAngle = function(radianAngle) {
     return radianAngle;
 }
 
+// Convert to radian, making negative angles positive
+const degreeToRadian = function(degreeAngle){
+  return ( (degreeAngle + 360) % 360) / 180 * Math.PI;
+}
+
 module.exports = {
+  degreeToRadian,
   standardizeAngle
 }

--- a/src/bot/functions/function-utils.js
+++ b/src/bot/functions/function-utils.js
@@ -1,0 +1,15 @@
+const standardizeAngle = function(radianAngle) {
+    // standardize angle to between 0 and Math.PI*2
+    while (radianAngle > Math.PI*2) {
+      radianAngle -= Math.PI*2;
+    }
+    while (radianAngle < 0) {
+      radianAngle += Math.PI*2;
+    }
+
+    return radianAngle;
+}
+
+module.exports = {
+  standardizeAngle
+}

--- a/src/bot/functions/rotate-barrel-to.js
+++ b/src/bot/functions/rotate-barrel-to.js
@@ -3,7 +3,7 @@
 module.exports = function(degreeAngle, callback) {
   console.log('rotateBarrelTo');
   let ad = this.barrel.rotation / Math.PI * 180;
-  let angle = ((degreeAngle+360) % 360) /180 * Math.PI; //Convert to radian, making negative angles positive
+  let angle = utils.degreeToRadian(degreeAngle);
 
   // standardize angle to less than Math.PI away from this.barrel.rotation (shortest direction)
   while (angle < this.barrel.rotation - Math.PI) {
@@ -29,7 +29,6 @@ module.exports = function(degreeAngle, callback) {
 
 function rotateBarrelTo(angle, elapsedMs) {
   let r = this.barrel.rotationVelocity * elapsedMs;
-
   if ((this.barrel.rotation <= angle && this.barrel.rotation + r >= angle) || (this.barrel.rotation >= angle && this.barrel.rotation + r <= angle)) {
     this.barrel.rotationVelocity = 0;
     this.barrel.rotation = angle;

--- a/src/bot/functions/rotate-barrel-to.js
+++ b/src/bot/functions/rotate-barrel-to.js
@@ -1,3 +1,5 @@
+ const utils = require('./function-utils');
+
 module.exports = function(degreeAngle, callback) {
   console.log('rotateBarrelTo');
   let ad = this.barrel.rotation / Math.PI * 180;
@@ -28,22 +30,16 @@ module.exports = function(degreeAngle, callback) {
 function rotateBarrelTo(angle, elapsedMs) {
   let r = this.barrel.rotationVelocity * elapsedMs;
 
-  // standardize angle to between 0 and Math.PI*2
-  while (this.barrel.rotation > Math.PI*2) {
-    this.barrel.rotation -= Math.PI*2;
-  }
-  while (this.barrel.rotation < 0) {
-    this.barrel.rotation += Math.PI*2;
-  }
-
   if ((this.barrel.rotation <= angle && this.barrel.rotation + r >= angle) || (this.barrel.rotation >= angle && this.barrel.rotation + r <= angle)) {
     this.barrel.rotationVelocity = 0;
     this.barrel.rotation = angle;
 
+    this.barrel.rotation = utils.standardizeAngle(this.barrel.rotation);
     return { finished: true };
   }
   else {
     this.barrel.rotation += r;
+    this.barrel.rotation = utils.standardizeAngle(this.barrel.rotation);
   }
   return { finished: false };
 }

--- a/src/bot/functions/rotate-barrel-to.js
+++ b/src/bot/functions/rotate-barrel-to.js
@@ -1,7 +1,7 @@
 module.exports = function(degreeAngle, callback) {
   console.log('rotateBarrelTo');
   let ad = this.barrel.rotation / Math.PI * 180;
-  let angle = degreeAngle/180 * Math.PI;
+  let angle = ((degreeAngle+360) % 360) /180 * Math.PI; //Convert to radian, making negative angles positive
 
   // standardize angle to less than Math.PI away from this.barrel.rotation (shortest direction)
   while (angle < this.barrel.rotation - Math.PI) {
@@ -27,17 +27,18 @@ module.exports = function(degreeAngle, callback) {
 
 function rotateBarrelTo(angle, elapsedMs) {
   let r = this.barrel.rotationVelocity * elapsedMs;
-  if ((this.barrel.rotation < angle && this.barrel.rotation + r >= angle) || (this.barrel.rotation > angle && this.barrel.rotation + r <= angle)) {
+
+  // standardize angle to between 0 and Math.PI*2
+  while (this.barrel.rotation > Math.PI*2) {
+    this.barrel.rotation -= Math.PI*2;
+  }
+  while (this.barrel.rotation < 0) {
+    this.barrel.rotation += Math.PI*2;
+  }
+
+  if ((this.barrel.rotation <= angle && this.barrel.rotation + r >= angle) || (this.barrel.rotation >= angle && this.barrel.rotation + r <= angle)) {
     this.barrel.rotationVelocity = 0;
     this.barrel.rotation = angle;
-
-    // standardize angle to between 0 and Math.PI*2
-    while (this.barrel.rotation > Math.PI*2) {
-      this.barrel.rotation -= Math.PI*2;
-    }
-    while (this.barrel.rotation < 0) {
-      this.barrel.rotation += Math.PI*2;
-    }
 
     return { finished: true };
   }

--- a/src/bot/functions/rotate-to.js
+++ b/src/bot/functions/rotate-to.js
@@ -2,7 +2,7 @@ const utils = require('./function-utils');
 
 module.exports = function(degreeAngle, callback) {
   let ad = this.rotation / Math.PI * 180;
-  let angle = degreeAngle/180 * Math.PI;
+  let angle = utils.degreeToRadian(degreeAngle);
 
   // standardize angle to less than Math.PI away from this.rotation (shortest direction)
   while (angle < this.rotation - Math.PI) {

--- a/src/bot/functions/rotate-to.js
+++ b/src/bot/functions/rotate-to.js
@@ -1,3 +1,5 @@
+const utils = require('./function-utils');
+
 module.exports = function(degreeAngle, callback) {
   let ad = this.rotation / Math.PI * 180;
   let angle = degreeAngle/180 * Math.PI;
@@ -26,22 +28,16 @@ module.exports = function(degreeAngle, callback) {
 
 function rotateTo(angle, elapsedMs) {
   let r = this.rotationVelocity * elapsedMs;
-  if ((this.rotation < angle && this.rotation + r >= angle) || (this.rotation > angle && this.rotation + r <= angle)) {
+  if ((this.rotation <= angle && this.rotation + r >= angle) || (this.rotation >= angle && this.rotation + r <= angle)) {
     this.rotationVelocity = 0;
     this.rotation = angle;
 
-    // standardize angle to between 0 and Math.PI*2
-    while (this.rotation > Math.PI*2) {
-      this.rotation -= Math.PI*2;
-    }
-    while (this.rotation < 0) {
-      this.rotation += Math.PI*2;
-    }
-
+    this.rotation = utils.standardizeAngle(this.rotation);
     return { finished: true };
   }
   else {
     this.rotation += r;
+    this.rotation = utils.standardizeAngle(this.rotation);
   }
   return { finished: false };
 }


### PR DESCRIPTION
- standardize angle between 0 and Math.PI*2 on every call (Put this in a utill?)
- when the function was called and `angle === this.rotation` it was doing a full rotation 
- normalize the angle when passed in (account for negative and %360)